### PR TITLE
fix(security): verify .runtime in .dockerignore (Closes #5)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 .git
+# Security: .runtime may contain env files with secrets (bearer tokens, AWS agent tokens)
 .runtime
 .venv
 __pycache__


### PR DESCRIPTION
## Summary
- Verified `.runtime` was already excluded in `.dockerignore` (line 2)
- Added security comment explaining the exclusion protects bearer tokens and AWS agent tokens from leaking into Docker image layers
- Part of cross-repo security hardening (see also personas-service#80)

## Test plan
- [x] `make lint` passes
- [x] `make test` passes (16/16)
- [x] `.runtime` remains in `.dockerignore`
- [x] Root Dockerfile uses selective COPY — no risk of `.runtime` leaking

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>