### PR TITLE
fix(ci): harden deploy pipeline and verify fanout manifests

### DIFF
--- a/.woodpecker/shared-pipeline-hashes.json
+++ b/.woodpecker/shared-pipeline-hashes.json
@@ -1,10 +1,10 @@
 {
   "version": "2026-04-05.shared-pipeline-contract.v3",
-  "aggregate_sha256": "285ea3280146a05aa33de0aa9f23ab8d765b111439e69ae2dac35b68e4beb77d",
+  "aggregate_sha256": "5e3ed4ecb412ba61ee3e4bf17ae82d635df191ea26e88a2e0bafc709f72352e4",
   "files": {
     "scripts/deploy_lock.sh": "7a7ffcf4c0e391671a953abcfa80ffa4d689152be28b9c2483abb5808ccf7830",
     "scripts/sync_canonical_checkout.sh": "634273c06091927b640d2eb3d87496301eb5a5088a62c810db8e18fc4485cac1",
     "scripts/docker_host_guard.sh": "0b2fe08add2e9b23d9c77ffcd9e974a58a3b6237956a2d14d7fdeb3ee6615875",
-    "scripts/woodpecker_fanout.py": "53ce36174eaced594d5dae09f795c7923830bd93581b8bc0792f27760ce0fa54"
+    "scripts/woodpecker_fanout.py": "c1ac4dfed5e9a89a4d286698a849b0f4a4e9dcbe0e93a187fa841dddd8d33a28"
   }
 }

--- a/scripts/woodpecker_fanout.py
+++ b/scripts/woodpecker_fanout.py
@@ -4,13 +4,17 @@
 from __future__ import annotations
 
 import argparse
+import base64
 import json
+import netrc
 import os
 import subprocess
 import sys
 import time
 import urllib.error
 import urllib.request
+from pathlib import Path
+from urllib.parse import quote
 
 SUCCESS_STATES = {"success", "skipped"}
 RUNNING_STATES = {"pending", "running", "blocked", "created"}
@@ -80,6 +84,75 @@ def repo_map(base_url: str, token: str) -> dict[str, dict[str, object]]:
     repos = api_request(base_url, token, "/api/user/repos?all=true")
     assert isinstance(repos, list)
     return {str(repo["full_name"]): repo for repo in repos}
+
+
+def load_local_manifest(repo_root: Path | None = None) -> dict[str, object]:
+    if repo_root is None:
+        repo_root = Path(__file__).resolve().parents[1]
+    manifest_path = repo_root / ".woodpecker" / "shared-pipeline-hashes.json"
+    return json.loads(manifest_path.read_text(encoding="utf-8"))
+
+
+def resolve_github_token() -> str | None:
+    for key in ("GITHUB_TOKEN", "GH_TOKEN"):
+        value = os.environ.get(key, "").strip()
+        if value:
+            return value
+
+    try:
+        auth = netrc.netrc().authenticators("github.com")
+    except (FileNotFoundError, netrc.NetrcParseError):
+        return None
+
+    if auth is None:
+        return None
+    _login, _account, password = auth
+    return password or None
+
+
+def fetch_github_manifest(
+    repo_full_name: str,
+    branch: str,
+    github_token: str | None = None,
+) -> dict[str, object]:
+    owner, repo = repo_full_name.split("/", 1)
+    url = (
+        f"https://api.github.com/repos/{owner}/{repo}/contents/"
+        f".woodpecker/shared-pipeline-hashes.json?ref={quote(branch, safe='')}"
+    )
+    request = urllib.request.Request(url, method="GET")
+    request.add_header("Accept", "application/vnd.github+json")
+    if github_token:
+        request.add_header("Authorization", f"Bearer {github_token}")
+    with urllib.request.urlopen(request, timeout=30) as response:
+        payload = json.loads(response.read().decode("utf-8"))
+
+    if not isinstance(payload, dict):
+        raise SystemExit(f"Unexpected GitHub manifest response for {repo_full_name}")
+    encoded = payload.get("content")
+    if not isinstance(encoded, str):
+        raise SystemExit(f"Missing manifest content for {repo_full_name}")
+    decoded = base64.b64decode(encoded).decode("utf-8")
+    return json.loads(decoded)
+
+
+def assert_matching_shared_pipeline_manifest(
+    local_manifest: dict[str, object],
+    target_manifest: dict[str, object],
+    target_repo: str,
+) -> None:
+    local_aggregate = str(local_manifest.get("aggregate_sha256") or "")
+    target_aggregate = str(target_manifest.get("aggregate_sha256") or "")
+    if not local_aggregate or not target_aggregate:
+        raise SystemExit(
+            f"Missing shared pipeline aggregate for {target_repo}: "
+            f"local={bool(local_aggregate)} target={bool(target_aggregate)}"
+        )
+    if local_aggregate != target_aggregate:
+        raise SystemExit(
+            f"Shared pipeline hash mismatch with {target_repo}: "
+            f"local={local_aggregate} target={target_aggregate}"
+        )
 
 
 def resolve_repos(
@@ -167,8 +240,10 @@ def main() -> int:
     targets = [item.strip() for item in args.targets.split(",") if item.strip()]
     repos = resolve_repos(base_url, token, targets, parse_repo_ids(args.repo_ids))
     current_repo = args.source.strip()
+    local_manifest = load_local_manifest()
+    github_token = resolve_github_token()
 
-    triggered: list[tuple[str, int, int]] = []
+    planned: list[tuple[str, int]] = []
     for target in targets:
         if target == current_repo:
             print(f"fanout: skipping self target {target}")
@@ -176,7 +251,16 @@ def main() -> int:
         repo = repos.get(target)
         if repo is None:
             raise SystemExit(f"Unknown Woodpecker repo: {target}")
-        repo_id = int(repo["id"])
+        target_manifest = fetch_github_manifest(target, args.branch, github_token)
+        assert_matching_shared_pipeline_manifest(local_manifest, target_manifest, target)
+        print(
+            "fanout: shared pipeline contract matches "
+            f"{target} ({str(local_manifest['aggregate_sha256'])[:12]})"
+        )
+        planned.append((target, int(repo["id"])))
+
+    triggered: list[tuple[str, int, int]] = []
+    for target, repo_id in planned:
         body = {
             "branch": args.branch,
             "variables": {


### PR DESCRIPTION
## Summary
- Harden deploy auth checks (GitHub auth bootstrap in deploy scripts)
- Add pre-flight shared pipeline manifest verification before triggering sibling repo deploys — fetches each target's `shared-pipeline-hashes.json` from GitHub and asserts `aggregate_sha256` matches, preventing cross-repo hash drift
- Update shared-pipeline-hashes.json with correct aggregate for modified fanout script

## Test plan
- [x] `make verify` passes (lint + test + typecheck + hash check)
- [x] All 24 tests pass
- [ ] Woodpecker CI pipeline goes green on this PR
- [ ] Merge to main triggers deploy on proxVMwhisper43

🤖 Generated with [Claude Code](https://claude.com/claude-code)