### PR TITLE
fix(infra): make deploy pipeline self-healing on the GPU VM

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,16 @@ Pipeline runs in Woodpecker CI via `.woodpecker/`:
 - **ci.yml**: lint + secret-scan + dockerfile-lint (parallel) -> test + typecheck + dependency-audit
 - **deploy-local.yml**: main-only local Docker deploy, depends on `ci`, pinned to `deploy-host=gpu-vm` agent
 
+Both pipelines are pinned to the `deploy-host=gpu-vm` agent, so whisper
+CI/CD is fully self-contained on proxVMwhisper43 and has no dependency on
+any other host being up. (CI was previously pinned to proxVMvoice18; when
+that VM went down, whisper pipelines queued forever and blocked deploys.)
+
+Deploy steps run in the `ghcr.io/cooneycw/ci-deploy:3.12` tooling image
+(bash/git/make/python3.12/docker CLI + compose). Its Dockerfile lives in
+`infra/ci-deploy/`. Pipelines use `pull: false`, so the image must exist
+locally on the GPU VM; the agent watchdog rebuilds it if pruned.
+
 ## Deployment Target
 
 - **Host:** 192.168.7.61 (local lab GPU VM)
@@ -117,4 +127,31 @@ This agent serves all three projects on the host: whisper-stt-bench, voice-bot-a
 cd woodpecker-agent
 ./bootstrap-agent.sh          # Fetch creds from AWS SM + start agent
 docker compose logs -f        # Check agent logs
+sudo ./install-watchdog.sh    # Install systemd watchdog timer (5 min)
 ```
+
+### Agent Watchdog
+
+`woodpecker-agent/watchdog.sh` runs every 5 minutes via systemd timer
+(`woodpecker-watchdog.timer`) and auto-recovers known failure modes:
+
+1. **Agent container stopped** -> `docker start`
+2. **gRPC queue desync** (agent looks "healthy" but stops claiming jobs;
+   pipelines sit "pending" forever) -> `docker restart` (15 min cooldown)
+3. **`ci-deploy:3.12` image pruned** by `docker_host_guard.sh` disk cleanup
+   -> rebuild from `infra/ci-deploy/`
+
+## CI/CD Troubleshooting
+
+- **Pipeline stuck "pending" (yellow)**: no agent with matching labels is
+  claiming it. Check `docker logs woodpecker-agent` for
+  `queue: task not found` / `extending pipeline deadline failed`
+  (desync -> restart agent), and confirm the pipeline's `labels:` match a
+  live agent. Retrigger by pushing a new commit (an orphaned queued task
+  may never be picked up even after the agent recovers).
+- **deploy-local fails with `error from registry: denied`**: the
+  `ci-deploy:3.12` image is missing locally and the registry copy is
+  unavailable. Rebuild:
+  `docker build -t ghcr.io/cooneycw/ci-deploy:3.12 infra/ci-deploy`
+- **Break-glass deploy** (Woodpecker down entirely): SSH to the GPU VM and
+  run `make deploy` from `/home/cooneycw/Projects/whisper-stt-bench`.

--- a/infra/ci-deploy/Dockerfile
+++ b/infra/ci-deploy/Dockerfile
@@ -1,0 +1,40 @@
+# CI deploy tooling image used by .woodpecker/deploy-local.yml and
+# .woodpecker/docker-cleanup.yml (ghcr.io/cooneycw/ci-deploy:3.12).
+#
+# Provides everything scripts/woodpecker_deploy.sh needs:
+#   bash, git, make, curl, python3.12 (stdlib only), docker CLI + compose
+#   plugin (daemon access via the mounted /var/run/docker.sock).
+#
+# Rebuild + publish (from repo root):
+#   docker build -t ghcr.io/cooneycw/ci-deploy:3.12 infra/ci-deploy
+#   docker push ghcr.io/cooneycw/ci-deploy:3.12
+#
+# NOTE: docker_host_guard.sh prunes unused images under disk pressure, and
+# the pipelines use `pull: false`. If this image disappears from the host,
+# the agent watchdog (woodpecker-agent/watchdog.sh) re-pulls it; worst case
+# rebuild it with the commands above.
+FROM python:3.12-slim-bookworm
+
+# hadolint ignore=DL3008
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        bash \
+        ca-certificates \
+        curl \
+        git \
+        gnupg \
+        make \
+    && install -m 0755 -d /etc/apt/keyrings \
+    && curl -fsSL https://download.docker.com/linux/debian/gpg \
+        -o /etc/apt/keyrings/docker.asc \
+    && chmod a+r /etc/apt/keyrings/docker.asc \
+    && echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian bookworm stable" \
+        > /etc/apt/sources.list.d/docker.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        docker-ce-cli \
+        docker-compose-plugin \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+CMD ["bash"]

--- a/woodpecker-agent/docker-compose.yml
+++ b/woodpecker-agent/docker-compose.yml
@@ -14,11 +14,16 @@
 services:
   woodpecker-agent:
     image: woodpeckerci/woodpecker-agent:v3.13.0
-    container_name: woodpecker-agent-gpu-vm
+    # NOTE: name and env below match the agent actually running on the GPU
+    # VM (which also serves cooneycw/agentic-asst). watchdog.sh keys off
+    # this container name — keep them in sync.
+    container_name: woodpecker-agent
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     env_file: agent.env
     environment:
       - WOODPECKER_MAX_WORKFLOWS=2
-      - WOODPECKER_FILTER_LABELS=platform=linux/amd64,deploy-host=gpu-vm
+      - WOODPECKER_AGENT_LABELS=deploy-host=gpu-vm
+      - WOODPECKER_HOSTNAME=proxVMwhisper43
+      - WOODPECKER_GRPC_SECURE=false
     restart: unless-stopped

--- a/woodpecker-agent/install-watchdog.sh
+++ b/woodpecker-agent/install-watchdog.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Install the Woodpecker agent watchdog as a systemd timer (every 5 min).
+#
+# Usage: sudo ./install-watchdog.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+chmod +x "$SCRIPT_DIR/watchdog.sh"
+cp "$SCRIPT_DIR/woodpecker-watchdog.service" /etc/systemd/system/
+cp "$SCRIPT_DIR/woodpecker-watchdog.timer" /etc/systemd/system/
+
+systemctl daemon-reload
+systemctl enable --now woodpecker-watchdog.timer
+
+echo "Installed. Status:"
+systemctl status woodpecker-watchdog.timer --no-pager | head -5
+echo
+echo "Logs: journalctl -u woodpecker-watchdog.service -n 20"

--- a/woodpecker-agent/watchdog.sh
+++ b/woodpecker-agent/watchdog.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Woodpecker agent + CI tooling watchdog for the GPU VM (proxVMwhisper43).
+#
+# Run periodically (systemd timer, see install-watchdog.sh). Recovers the
+# three failure modes that have caused CI/deploy outages on this host:
+#
+#   1. Agent container stopped        -> docker start
+#   2. Agent gRPC queue desync        -> docker restart
+#      (agent reports "healthy" but stops claiming jobs; log signature:
+#       "queue: task not found" / "extending pipeline deadline failed")
+#   3. ci-deploy tooling image pruned -> rebuild from infra/ci-deploy
+#      (docker_host_guard.sh prunes unused images under disk pressure and
+#       deploy pipelines use `pull: false`)
+set -euo pipefail
+
+AGENT_CONTAINER="${AGENT_CONTAINER:-woodpecker-agent}"
+CI_DEPLOY_IMAGE="${CI_DEPLOY_IMAGE:-ghcr.io/cooneycw/ci-deploy:3.12}"
+REPO_DIR="${REPO_DIR:-/home/cooneycw/Projects/whisper-stt-bench}"
+LOG_WINDOW="${LOG_WINDOW:-10m}"
+RESTART_COOLDOWN_S="${RESTART_COOLDOWN_S:-900}"
+STATE_FILE="${STATE_FILE:-/tmp/woodpecker-watchdog.last-restart}"
+
+log() { echo "[watchdog $(date -u +%FT%TZ)] $*"; }
+
+# --- 1. agent container must exist and be running -------------------------
+if ! docker inspect "$AGENT_CONTAINER" >/dev/null 2>&1; then
+    log "FATAL: agent container '$AGENT_CONTAINER' does not exist;" \
+        "recreate it via woodpecker-agent/bootstrap-agent.sh"
+    exit 1
+fi
+
+state="$(docker inspect -f '{{.State.Status}}' "$AGENT_CONTAINER")"
+if [ "$state" != "running" ]; then
+    log "agent state=$state; starting"
+    docker start "$AGENT_CONTAINER"
+fi
+
+# --- 2. gRPC queue desync -> restart (with cooldown) -----------------------
+# docker logs persist across restarts, so pre-restart error lines stay in
+# the time window for a while; the cooldown prevents a restart loop.
+last_restart=0
+[ -f "$STATE_FILE" ] && last_restart="$(cat "$STATE_FILE" 2>/dev/null || echo 0)"
+now="$(date +%s)"
+
+if docker logs --since "$LOG_WINDOW" "$AGENT_CONTAINER" 2>&1 \
+    | grep -qE "queue: task not found|extending pipeline deadline failed|connection refused|transport is closing"; then
+    if [ $((now - last_restart)) -ge "$RESTART_COOLDOWN_S" ]; then
+        log "queue desync signature in last $LOG_WINDOW; restarting agent"
+        docker restart "$AGENT_CONTAINER"
+        echo "$now" > "$STATE_FILE"
+    else
+        log "desync signature present but within restart cooldown; skipping"
+    fi
+fi
+
+# --- 3. ci-deploy tooling image must be present ----------------------------
+if ! docker image inspect "$CI_DEPLOY_IMAGE" >/dev/null 2>&1; then
+    log "$CI_DEPLOY_IMAGE missing (pruned?); rebuilding from $REPO_DIR/infra/ci-deploy"
+    if ! docker build -q -t "$CI_DEPLOY_IMAGE" "$REPO_DIR/infra/ci-deploy"; then
+        log "build failed; trying registry pull"
+        docker pull "$CI_DEPLOY_IMAGE" || {
+            log "FATAL: cannot restore $CI_DEPLOY_IMAGE (build and pull failed)"
+            exit 1
+        }
+    fi
+    log "$CI_DEPLOY_IMAGE restored"
+fi
+
+log "ok: agent running, tooling image present"

--- a/woodpecker-agent/woodpecker-watchdog.service
+++ b/woodpecker-agent/woodpecker-watchdog.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Woodpecker agent + CI tooling watchdog (GPU VM)
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+User=cooneycw
+ExecStart=/home/cooneycw/Projects/whisper-stt-bench/woodpecker-agent/watchdog.sh

--- a/woodpecker-agent/woodpecker-watchdog.timer
+++ b/woodpecker-agent/woodpecker-watchdog.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run the Woodpecker agent watchdog every 5 minutes
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=5min
+Unit=woodpecker-watchdog.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary
Hardens the Woodpecker CI/CD path after today's outage chain (CI pinned to a down host → orphaned queue tasks → deploy tooling image pruned with no registry fallback → agent gRPC zombie state):

- **infra/ci-deploy/**: in-repo Dockerfile for `ghcr.io/cooneycw/ci-deploy:3.12` (was hand-built, unpublished, and got pruned — killing deploys). Rebuilt locally on the GPU VM.
- **woodpecker-agent/watchdog.sh** (+ systemd timer, installed & enabled): auto-starts a stopped agent, restarts on gRPC queue-desync log signatures with cooldown, rebuilds the tooling image if pruned.
- **woodpecker-agent/docker-compose.yml**: reconciled with the actually-running agent config.
- **CLAUDE.md**: self-contained gpu-vm CI/CD topology, watchdog docs, troubleshooting runbook.

Merging this also re-triggers `deploy-local` on main, shipping the still-undeployed #23 API changes.

## Test plan
- [x] `bash woodpecker-agent/watchdog.sh` → "ok: agent running, tooling image present"
- [x] systemd timer active (`woodpecker-watchdog.timer` enabled, first run green)
- [x] hadolint clean on new Dockerfile; toolchain verified inside built image
- [x] `make lint` green
- [ ] deploy-local green on main after merge; live OpenAPI shows `initial_prompt` + confidence fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)