### PR TITLE
fix(deploy): mount ~/.netrc into deploy step for GitHub auth

### DIFF
--- a/.woodpecker/deploy-local.yml
+++ b/.woodpecker/deploy-local.yml
@@ -18,6 +18,10 @@ steps:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - /home/cooneycw/.aws:/home/cooneycw/.aws:ro
+      # .netrc is the primary GitHub auth for canonical checkout sync +
+      # fanout; hosts.yml is a fallback but modern gh keeps the token in
+      # the system keyring, so hosts.yml alone no longer works.
+      - /home/cooneycw/.netrc:/root/.netrc:ro
       - /home/cooneycw/.config/gh:/root/.config/gh:ro
       - /home/cooneycw/Projects:/home/cooneycw/Projects
     commands:


### PR DESCRIPTION
## Summary
deploy-local (pipeline #96) failed with `FATAL: missing GitHub auth in CI`: the auth bootstrap awk-extracts `oauth_token:` from gh's hosts.yml, but modern gh stores tokens in the system keyring — hosts.yml no longer carries a token. Mount the host `~/.netrc` (written from `gh auth token`, mode 600) as `/root/.netrc`, which `woodpecker_deploy.sh` already prefers as its primary auth source.

## Test plan
- [x] Reproduced #96 failure locally in the ci-deploy container (exact FATAL)
- [x] With the netrc mount: authenticated `git ls-remote` succeeds in-container
- [ ] deploy-local green on main after merge; live OpenAPI shows the #23 fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)