### PR TITLE
fix(auth): make secrets sidecar start — generate SSRF token in entrypoint

### DIFF
--- a/infra/secrets-manager-agent/Dockerfile
+++ b/infra/secrets-manager-agent/Dockerfile
@@ -23,5 +23,10 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /build/src/target/release/aws_secretsmanager_agent /usr/local/bin/secrets-manager-agent
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
 
-ENTRYPOINT ["/usr/local/bin/secrets-manager-agent"]
+# entrypoint.sh generates the SSRF token file into the shared volume and
+# exports AWS_TOKEN before exec'ing the agent (the agent refuses to start
+# without an SSRF token source).
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/infra/secrets-manager-agent/entrypoint.sh
+++ b/infra/secrets-manager-agent/entrypoint.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Entrypoint for the AWS Secrets Manager Agent sidecar.
+#
+# The agent requires its SSRF token via AWS_TOKEN (or AWS_SESSION_TOKEN /
+# AWS_CONTAINER_AUTHORIZATION_TOKEN); nothing generates that token file by
+# itself. Generate a random token into the shared awssmatoken volume so the
+# whisper-bench app (which reads AWS_TOKEN=file:///run/awssmatoken/token)
+# and the agent agree on it, then exec the agent.
+set -euo pipefail
+
+TOKEN_FILE="${AWS_TOKEN_FILE_PATH:-/run/awssmatoken/token}"
+
+mkdir -p "$(dirname "$TOKEN_FILE")"
+if [ ! -s "$TOKEN_FILE" ]; then
+    od -An -tx1 -N32 /dev/urandom | tr -d ' \n' > "$TOKEN_FILE"
+fi
+chmod 0644 "$TOKEN_FILE"
+
+export AWS_TOKEN="file://$TOKEN_FILE"
+
+exec /usr/local/bin/secrets-manager-agent "$@"


### PR DESCRIPTION
## Summary
The secrets sidecar crash-looped since introduction: the AWS SM Agent requires its SSRF token via `AWS_TOKEN`/equivalents, but compose only set `AWS_TOKEN_FILE_PATH` (ignored) and nothing generated the token file. Result: the app never loaded a bearer token and `/v1/transcribe` ran **unprotected** in dev mode.

- New sidecar entrypoint generates the SSRF token into the shared `awssmatoken` volume (path the app already reads) and exports `AWS_TOKEN` before exec'ing the agent.
- Provisioned out-of-band: AWS SM secret `whisper-stt-bench` (key `whisper_bearer_token`), host `.env` with `WHISPER_BENCH_AWS_SECRET_NAME=whisper-stt-bench`.

## Test plan
- [x] hadolint clean
- [x] Sidecar stable locally: `Agent/1.2.1 listening on http://127.0.0.1:2773`
- [x] Secret fetch from app container through agent returns `whisper_bearer_token`
- [ ] After merge+deploy: `/v1/transcribe` returns 401 without/with-wrong token, 200 with token; `/health` stays open

⚠️ Enabling auth is a breaking change for unauthenticated callers (agentic-asst must configure the token — see cooneycw/agentic-asst#464).

🤖 Generated with [Claude Code](https://claude.com/claude-code)